### PR TITLE
feat: export get vm type native currency and encoding adjust

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import {
   encodeAddress,
   encodeBytes,
   encodeTransactionId,
+  getVmTypeNativeCurrency,
 } from "./utils";
 
 export {
@@ -70,6 +71,7 @@ export {
   encodeAddress,
   encodeBytes,
   encodeTransactionId,
+  getVmTypeNativeCurrency,
 
   // Messages v2.1
 

--- a/src/messages/v2.1/depository-withdrawal.ts
+++ b/src/messages/v2.1/depository-withdrawal.ts
@@ -174,12 +174,12 @@ export const encodeWithdrawal = (
     }
 
     case "tron-vm": {
-      const callsArray = decodedWithdrawal.withdrawal.calls.map(c => ([
+      const callsArray = decodedWithdrawal.withdrawal.calls.map((c) => [
         c.to.replace(tronweb.utils.address.ADDRESS_PREFIX_REGEX, "0x"),
         c.data,
         BigInt(c.value),
         Boolean(c.allowFailure),
-      ]));
+      ]);
 
       const types = [
         "tuple(tuple(address,bytes,uint256,bool)[],uint256,uint256)",

--- a/src/messages/v2.1/depository-withdrawal.ts
+++ b/src/messages/v2.1/depository-withdrawal.ts
@@ -175,7 +175,7 @@ export const encodeWithdrawal = (
 
     case "tron-vm": {
       const callsArray = decodedWithdrawal.withdrawal.calls.map(c => ([
-        c.to.replace(tronweb.utils.address.ADDRESS_PREFIX, "0x"),
+        c.to.replace(tronweb.utils.address.ADDRESS_PREFIX_REGEX, "0x"),
         c.data,
         BigInt(c.value),
         !!c.allowFailure


### PR DESCRIPTION
- export getVmTypeNativeCurrency
- use prefix regx to avoid replace random address like `9041aaaa` into `900xaaaa`